### PR TITLE
[feat] Create ResultModel and create_result, result_list (OSINT-275)

### DIFF
--- a/server/db_conn/mongo/models.py
+++ b/server/db_conn/mongo/models.py
@@ -18,6 +18,7 @@ class ResultModel(db.DynamicDocument):
             elif isinstance(data,list):
                 result_obj = ResultModel(result=data)
             else:
+                #return status, data
                 return None, "Invalid data type"
 
             result_obj.save()
@@ -30,7 +31,7 @@ class ResultModel(db.DynamicDocument):
             return None, f'{cls.col_name} : Result Creation Error: {e}'
 
     @classmethod
-    def result_list(cls, result_id):
+    def get_result_list(cls, result_id):
         result = ResultModel.objects(result_id=result_id).first()
         if result:
             return True, result.result

--- a/server/osint/requirements.txt
+++ b/server/osint/requirements.txt
@@ -7,4 +7,4 @@ Werkzeug==2.2.2
 neo4j==5.12.0
 neomodel==5.1.2
 python-whois
-maigret
+maigret==0.4.4

--- a/server/osint/tools/tool.py
+++ b/server/osint/tools/tool.py
@@ -73,7 +73,7 @@ def run_tool():
 
     else:
         return jsonify({'Message': 'Invalid tool_id'}), 400
-
+    
     # Returning run_id
     if isinstance(run_id, int):
         return jsonify({'run_id': run_id}), 200

--- a/server/osint/tools/tool.py
+++ b/server/osint/tools/tool.py
@@ -116,3 +116,4 @@ def tool_state(run_id):
         return jsonify(response), 200
     else:
         return jsonify({"message": "run.status error"}), 400
+

--- a/server/src/resource/tool.py
+++ b/server/src/resource/tool.py
@@ -1,7 +1,7 @@
 from flask import request, jsonify,Blueprint
 
 from db_conn.mongo.init import db 
-from db_conn.mongo.models import CaseModel, ResultModel
+from db_conn.mongo.models import CaseModel, RunModel
 
 
 bp = Blueprint('tool', __name__, url_prefix='/tool')

--- a/server/src/resource/tool.py
+++ b/server/src/resource/tool.py
@@ -1,7 +1,7 @@
 from flask import request, jsonify,Blueprint
 
 from db_conn.mongo.init import db 
-from db_conn.mongo.models import CaseModel
+from db_conn.mongo.models import CaseModel, ResultModel
 
 
 bp = Blueprint('tool', __name__, url_prefix='/tool')
@@ -24,3 +24,5 @@ def create_run():
         return jsonify({'msg':'good'}), 200
     else:
         return jsonify({'msg':'error'}), 400
+
+


### PR DESCRIPTION
# [OSINT-275] Issue name
## 🔑 Key Change 
- Create ResultModel and create_result
- Create get_all_results in RunModel 

## 🖼️ Screenshots (if necessary)
- Result DB
<img width="717" alt="스크린샷 2023-10-31 오후 5 07 54" src="https://github.com/ICHEaccount/Ossistant/assets/65109465/ed8ce006-6b9c-4d2e-8cc1-fd53440d1e2e">

- Run DB
<img width="441" alt="스크린샷 2023-10-31 오후 5 05 34" src="https://github.com/ICHEaccount/Ossistant/assets/65109465/438ef04f-8a35-483b-b75e-c75694e4780c">

- get_all_results 
<img width="306" alt="스크린샷 2023-10-31 오후 5 06 32" src="https://github.com/ICHEaccount/Ossistant/assets/65109465/89be8e42-1ca8-42f6-8336-f9679f94a280">

## 🙏 To Reviewers
🧑‍🤝‍🧑 @Teammate
@ahrufox : The return value of `create_result`, `get_all_results` is status, data. If status is None, you can get data as error message. 
#### Sample
```python
@bp.route('/createResult/<string:p>', methods=['GET'])
def create_result(p):
    if p == '1':
        data  = {'a': 'data', 'b': 'data2'}
        status, msg = ResultModel.create_result(data=data, run_id=9)
        if status == None:
            return jsonify({'error':msg}), 500
        return jsonify({'msg':data}), 200
```

@R3D1NM : Check plz 


[OSINT-275]: https://bob-transfer.atlassian.net/browse/OSINT-275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ