### PR TITLE
[feat] view spec of node clicked on relGraph

### DIFF
--- a/client/src/components/visualization/relation/relationGraph.js
+++ b/client/src/components/visualization/relation/relationGraph.js
@@ -12,7 +12,7 @@ function RelationGraph(props) {
   const case_id = params.case_id;
   const isDone = props.isDone
   const dispatch = useDispatch()
-  const selected = useSelector(state => state.node.selected)
+  // const selected = useSelector(state => state.node.selected)
   const visJSRef = useRef(null)
   const [selectedNode, setSelectedNode] = useState(null); 
   const [selectedEdge, setSelectedEdge] = useState(null);
@@ -61,7 +61,10 @@ function RelationGraph(props) {
       if (nodes.length > 0) {
         axios.get(`/graph/node/${nodes[0]}`).then((response) =>{
           const resData = response.data;
+          const label = resData.property.label;
+          delete resData.property.label;
           console.log(resData);
+          dispatch(select({node:resData,label:label}))
         })
         setSelectedNode(nodes[0]);
       } else {
@@ -69,7 +72,7 @@ function RelationGraph(props) {
       }
     });
 
-  }, [isDone,visJSRef,selected]);
+  }, [isDone,visJSRef]);
 
   return (
       <><div ref={visJSRef} style={{ height: "400px", width: "900px", position: 'relative'}}></div>

--- a/server/src/resource/graph.py
+++ b/server/src/resource/graph.py
@@ -61,7 +61,7 @@ def test(uid):
     if uid:
         result = get_node_properties_by_uid(uid)
         if result:
-            keys_to_remove = ['case_id', 'label', 'uid', 'url']
+            keys_to_remove = ['case_id', 'uid', 'url']
             for key in keys_to_remove:
                 if key in result:
                     del result[key]


### PR DESCRIPTION
# [OSINT-318] Redux 적용
## 🔑 Key Change 
- data panel will show the specification of the node which user clicked on relation graph

## 🖼️ Screenshots (if necessary)
the mouse looks weird but I clicked the two nodes sequentially
[Screenshot 2023-11-09 at 14.18.28.webm](https://github.com/ICHEaccount/Ossistant/assets/93309715/4c86c70b-1eba-451d-8fd2-73fec0a44612)


## 🙏 To Reviewers
🧑‍🤝‍🧑 @D7MeKz 
- I changed /graph/node api a little, so plz check that out
- It just works well :)


[OSINT-318]: https://bob-transfer.atlassian.net/browse/OSINT-318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ